### PR TITLE
[DEV] 전처리기 기능 구현

### DIFF
--- a/backend/app/db/db_load.py
+++ b/backend/app/db/db_load.py
@@ -20,25 +20,25 @@ MAX_EVIDENCES_PER_CALL = 100
 
 def load_prompt(prompt_id: ObjectId | str) -> Optional[Dict[str, Any]]:
     _id = ObjectId(prompt_id) if not isinstance(prompt_id, ObjectId) else prompt_id
-    c = get_client(); db = get_db(c)
+    db = get_db()
     return db[PROMPT_COLL].find_one({"_id": _id})
 
 def worker_load_trigger(trigger_id: ObjectId | str) -> Optional[Dict[str, Any]]:
     _tid = ObjectId(trigger_id) if not isinstance(trigger_id, ObjectId) else trigger_id
-    c = get_client(); db = get_db(c)
+    db = get_db()
     return db[TRIGGER_COLL].find_one({"_id": _tid})
 
 def get_latest_done_trigger() -> Optional[Dict[str, Any]]:
-    c = get_client(); db = get_db(c)
+    db = get_db()
     return db[TRIGGER_COLL].find_one({"status":"done"}, sort=[("finished_at",-1)])
 
 def agent_get_latest_report_by_batch(batch_id: str) -> Optional[Dict[str, Any]]:
-    c = get_client(); db = get_db(c)
+    db = get_db()
     return db[REPORTS_COLL].find_one({"batch_id": batch_id}, sort=[("created_at", -1)])
 
 def agent_load_report_by_id(report_id: str | ObjectId) -> Optional[Dict[str, Any]]:
     _id = ObjectId(report_id) if not isinstance(report_id, ObjectId) else report_id
-    c = get_client(); db = get_db(c)
+    db = get_db()
     return db[REPORTS_COLL].find_one({"_id": _id})
 
 def get_used_evidence_set(trigger_doc: Dict[str, Any]) -> Set[Tuple[str, ObjectId]]:

--- a/backend/app/db/db_upload.py
+++ b/backend/app/db/db_upload.py
@@ -95,83 +95,76 @@ def upload_file(
     if p.is_dir():
         raise IsADirectoryError(f"{p} is a directory (expected a file)")
 
-    client = get_client()
-    try:
-        db = get_db(client)
+    db = get_db()
 
-        size = p.stat().st_size
-        content_type, _ = mimetypes.guess_type(p.name)
-        dtype = (detected_type or _infer_dtype(p, content_type))
+    size = p.stat().st_size
+    content_type, _ = mimetypes.guess_type(p.name)
+    dtype = (detected_type or _infer_dtype(p, content_type))
 
-        strategy = choose_strategy(size, mode, inline_threshold_bytes)
+    strategy = choose_strategy(size, mode, inline_threshold_bytes)
 
-        if strategy == "inline" and dtype == "json" and size > MAX_INLINE_JSON_BYTES:
-            strategy = "gridfs"
+    if strategy == "inline" and dtype == "json" and size > MAX_INLINE_JSON_BYTES:
+        strategy = "gridfs"
 
-        result: Dict[str, Any] = {"strategy": strategy}
+    result: Dict[str, Any] = {"strategy": strategy}
 
-        if strategy == "inline":
-            meta_doc: Dict[str, Any] = {
-                "source_type": "file_inline",
-                "filename": p.name,
-                "content_type": content_type or "application/octet-stream",
-                "size": size,
-                "detected_type": dtype,
-                "ingested_at": int(time.time()),
-                "stats": {},
-            }
-            try:
-                if dtype == "json":
-                    txt = p.read_text(encoding="utf-8", errors="strict")
-                    meta_doc["data"] = json.loads(txt)
-                else:
-                    raw = p.read_bytes()
-                    if len(raw) >= BSON_DOC_HARD_LIMIT - 1024:
-                        raise ValueError("inline BSON size would exceed limit; use gridfs")
-                    meta_doc["raw"] = Binary(raw)
-            except Exception as e:
-                meta_doc["stats"]["parse_error"] = str(e)
-                raw = p.read_bytes()
-                if len(raw) >= BSON_DOC_HARD_LIMIT - 1024:
-                    strategy = "gridfs"
-                else:
-                    meta_doc["raw"] = Binary(raw)
-
-            if strategy == "inline":
-                result["meta_id"] = insert_file_meta(db, collection, meta_doc)
-                return result
-
-        fs = get_fs(db)
-        files_doc = store_file_to_gridfs(fs, str(p), extra_meta={"detected_type": dtype})
-
-        sample: Optional[Any] = None
-        try:
-            if dtype == "json" or (content_type and "text" in content_type):
-                sample = (p.read_text(encoding="utf-8", errors="ignore"))[:GRIDFS_SAMPLE_BYTES]
-            else:
-                sample = Binary(p.read_bytes()[:GRIDFS_SAMPLE_BYTES])
-        except Exception:
-            sample = None
-
-        meta_doc = {
-            "source_type": "file",
-            "gridfs_id": files_doc["_id"],
-            "filename": files_doc.get("filename"),
-            "content_type": (files_doc.get("metadata") or {}).get("content_type"),
-            "size": files_doc.get("length"),
+    if strategy == "inline":
+        meta_doc: Dict[str, Any] = {
+            "source_type": "file_inline",
+            "filename": p.name,
+            "content_type": content_type or "application/octet-stream",
+            "size": size,
             "detected_type": dtype,
             "ingested_at": int(time.time()),
             "stats": {},
-            "sample": sample,
         }
-        result["meta_id"] = insert_file_meta(db, collection, meta_doc)
-        result["gridfs_id"] = str(files_doc["_id"])
-        return result
-    finally:
         try:
-            client.close()
-        except Exception:
-            pass
+            if dtype == "json":
+                txt = p.read_text(encoding="utf-8", errors="strict")
+                meta_doc["data"] = json.loads(txt)
+            else:
+                raw = p.read_bytes()
+                if len(raw) >= BSON_DOC_HARD_LIMIT - 1024:
+                    raise ValueError("inline BSON size would exceed limit; use gridfs")
+                meta_doc["raw"] = Binary(raw)
+        except Exception as e:
+            meta_doc["stats"]["parse_error"] = str(e)
+            raw = p.read_bytes()
+            if len(raw) >= BSON_DOC_HARD_LIMIT - 1024:
+                strategy = "gridfs"
+            else:
+                meta_doc["raw"] = Binary(raw)
+
+        if strategy == "inline":
+            result["meta_id"] = insert_file_meta(db, collection, meta_doc)
+            return result
+
+    fs = get_fs(db)
+    files_doc = store_file_to_gridfs(fs, str(p), extra_meta={"detected_type": dtype})
+
+    sample: Optional[Any] = None
+    try:
+        if dtype == "json" or (content_type and "text" in content_type):
+            sample = (p.read_text(encoding="utf-8", errors="ignore"))[:GRIDFS_SAMPLE_BYTES]
+        else:
+            sample = Binary(p.read_bytes()[:GRIDFS_SAMPLE_BYTES])
+    except Exception:
+        sample = None
+
+    meta_doc = {
+        "source_type": "file",
+        "gridfs_id": files_doc["_id"],
+        "filename": files_doc.get("filename"),
+        "content_type": (files_doc.get("metadata") or {}).get("content_type"),
+        "size": files_doc.get("length"),
+        "detected_type": dtype,
+        "ingested_at": int(time.time()),
+        "stats": {},
+        "sample": sample,
+    }
+    result["meta_id"] = insert_file_meta(db, collection, meta_doc)
+    result["gridfs_id"] = str(files_doc["_id"])
+    return result
 
 def preprocessor_upload_file(
     file_path: str,
@@ -189,7 +182,7 @@ def preprocessor_upload_file(
         inline_threshold_bytes=inline_threshold_bytes,
     )
     if extra_meta:
-        c = get_client(); db = get_db(c)
+        db = get_db()
         db[INPUT_EVIDENCE_COLL].update_one(
             {"_id": ObjectId(res["meta_id"])},
             {"$set": extra_meta}
@@ -204,7 +197,7 @@ def preprocessor_save_prompt(
     attachments: Optional[List[Dict[str, Any]]] = None,
     context_tags: Optional[List[str]] = None,
 ) -> ObjectId:
-    c = get_client(); db = get_db(c)
+    db = get_db()
     doc = {
         "created_at": _now(),
         "user_prompt": user_prompt,
@@ -250,7 +243,7 @@ def agent_mcp_upload_file(
         mode=mode,
         inline_threshold_bytes=inline_threshold_bytes,
     )
-    c = get_client(); db = get_db(c)
+    db = get_db()
     db[MCP_EVIDENCE_COLL].update_one(
         {"_id": ObjectId(r["meta_id"])},
         {"$set": {
@@ -271,7 +264,7 @@ def agent_start_trigger(
     include_all_input: bool = True,
     max_refs_per_trigger: Optional[int] = None,
 ) -> ObjectId:
-    c = get_client(); db = get_db(c)
+    db = get_db()
     snapshot_ts = _now()
 
     refs: List[Dict[str, Any]] = []
@@ -309,7 +302,7 @@ def agent_append_mcp_evidence(
     if not ids:
         return False
 
-    c = get_client(); db = get_db(c)
+    db = get_db()
     res = db[TRIGGER_COLL].update_one(
         {"_id": _tid, "status": {"$in": ["collecting", "ready"]}},
         {"$push": {"evidence_refs": {"$each": [
@@ -323,7 +316,7 @@ def agent_finish_trigger_ready(
     trigger_id: ObjectId | str,
 ) -> bool:
     _tid = ObjectId(trigger_id) if not isinstance(trigger_id, ObjectId) else trigger_id
-    c = get_client(); db = get_db(c)
+    db = get_db()
     res = db[TRIGGER_COLL].update_one(
         {"_id": _tid, "status": "collecting"},
         {"$set": {"status": "ready", "timeframe.end": _now()}}
@@ -332,7 +325,7 @@ def agent_finish_trigger_ready(
 
 def worker_lock_trigger_ready_to_processing(trigger_id: ObjectId | str) -> bool:
     _tid = ObjectId(trigger_id) if not isinstance(trigger_id, ObjectId) else trigger_id
-    c = get_client(); db = get_db(c)
+    db = get_db()
     res = db[TRIGGER_COLL].update_one(
         {"_id": _tid, "status": "ready"},
         {"$set": {"status": "processing", "started_at": _now()}}
@@ -361,7 +354,7 @@ def worker_save_report_and_mark_done(
     confidence: Optional[Dict[str, Any]] = None,
 ) -> ObjectId:
     _tid = ObjectId(trigger_id) if not isinstance(trigger_id, ObjectId) else trigger_id
-    c = get_client(); db = get_db(c)
+    db = get_db()
 
     rk = _run_key(sources, evidence_refs)
     existing = db[REPORTS_COLL].find_one({"run_key": rk}, {"_id": 1})

--- a/backend/app/domains/evidences/preprocessor/file_preprocessing.py
+++ b/backend/app/domains/evidences/preprocessor/file_preprocessing.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 import xml.etree.ElementTree as ET
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parents[5]
 DATA_DIR = BASE_DIR / "data"
 SUPPORTED_EXTS = {".json", ".jsonl", ".xml", ".csv"}
 

--- a/backend/app/domains/evidences/router.py
+++ b/backend/app/domains/evidences/router.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 from fastapi import APIRouter, HTTPException, Query
 from typing import Optional
 from .schema import EvidenceFromConversationIn, EvidenceCreatedOut, EvidenceListOut, EvidenceInputDetail
@@ -34,20 +33,3 @@ def get_preview(evidence_id: str):
     if not result:
         raise HTTPException(404, "not found")
     return result
-=======
-from fastapi import APIRouter
-
-router = APIRouter()
-
-@router.post("/input", summary="전처리기 증거 업로드")
-def upload_preprocessor_evidence():
-    return
-
-@router.get("/input/{evidence_id}", summary="전처리기 증거 상세 조회")
-def get_preprocessor_evidence():
-    return
-
-@router.get("", summary="전체 증거 목록 조회")
-def get_evidences():
-    return
->>>>>>> origin/dev/input-evidence

--- a/backend/app/domains/evidences/router.py
+++ b/backend/app/domains/evidences/router.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post("/input", summary="전처리기 증거 업로드")
+def upload_preprocessor_evidence():
+    return
+
+@router.get("/input/{evidence_id}", summary="전처리기 증거 상세 조회")
+def get_preprocessor_evidence():
+    return
+
+@router.get("", summary="전체 증거 목록 조회")
+def get_evidences():
+    return

--- a/backend/app/domains/evidences/router.py
+++ b/backend/app/domains/evidences/router.py
@@ -1,15 +1,35 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
+from .schema import EvidenceFromConversationIn, EvidenceCreatedOut, EvidenceListOut, EvidenceInputDetail
+from .service import create_evidences_from_latest_message, list_input_evidences, get_input_evidence_detail, preview_input_evidence
 
 router = APIRouter()
 
-@router.post("/input", summary="전처리기 증거 업로드")
-def upload_preprocessor_evidence():
-    return
+@router.post("/input", response_model=EvidenceCreatedOut, summary="사용자 프롬프트 내용에서 전처리기 증거 추출 및 변환 후 저장")
+def create_from_conversation(body: EvidenceFromConversationIn):
+    try:
+        res = create_evidences_from_latest_message(conversation_id=body.conversation_id, inline_threshold=body.inline_threshold)
+        return EvidenceCreatedOut.model_validate(res)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"internal error: {e}")
 
-@router.get("/input/{evidence_id}", summary="전처리기 증거 상세 조회")
-def get_preprocessor_evidence():
-    return
+@router.get("", response_model=EvidenceListOut, summary="전체 증거 목록 조회")
+def list_all(conversation_id: Optional[str] = Query(None), stage_id: Optional[int] = Query(None), limit: int = Query(100, ge=1, le=1000)):
+    items = list_input_evidences(conversation_id, stage_id, limit)
+    return EvidenceListOut(items=items)
 
-@router.get("", summary="전체 증거 목록 조회")
-def get_evidences():
-    return
+@router.get("/input/{evidence_id}", response_model=EvidenceInputDetail, summary="전처리기 증거 상세 조회")
+def get_detail(evidence_id: str):
+    d = get_input_evidence_detail(evidence_id)
+    if not d:
+        raise HTTPException(status_code=404, detail="not found")
+    return EvidenceInputDetail.model_validate(d)
+
+@router.get("/input/{evidence_id}/preview", summary="전처리기 증거 상세 조회(GridFS 샘플 확인)")
+def get_preview(evidence_id: str):
+    result = preview_input_evidence(evidence_id)
+    if not result:
+        raise HTTPException(404, "not found")
+    return result

--- a/backend/app/domains/evidences/schema.py
+++ b/backend/app/domains/evidences/schema.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import List, Optional, Literal
+from pydantic import BaseModel, Field
+
+class EvidenceFromConversationIn(BaseModel):
+    conversation_id: str
+    mode: Optional[str] = Field("auto")
+    inline_threshold: int = 10 * 1024 * 1024
+
+class EvidenceCreatedItem(BaseModel):
+    evidence_id: str
+    type: Optional[str] = None
+    strategy: Literal["inline", "gridfs"]
+    data_gridfs_id: Optional[str] = None
+    filename: str
+    size: int
+
+class EvidenceCreatedOut(BaseModel):
+    prompt_id: Optional[str] = None
+    items: List[EvidenceCreatedItem]
+
+class EvidenceListItem(BaseModel):
+    _id: str
+    conversation_id: Optional[str] = None
+    stage_id: Optional[int] = None
+    filename: Optional[str] = None
+    size: Optional[int] = None
+    created_at: Optional[datetime] = None
+
+class EvidenceListOut(BaseModel):
+    items: List[EvidenceListItem]
+
+class EvidenceInputDetail(BaseModel):
+    _id: str
+    conversation_id: Optional[str] = None
+    stage_id: Optional[int] = None
+    filename: Optional[str] = None
+    size: Optional[int] = None
+    data: Optional[dict] = None
+    data_gridfs_id: Optional[str] = None
+    ingested_at: Optional[datetime] = None

--- a/backend/app/domains/evidences/service.py
+++ b/backend/app/domains/evidences/service.py
@@ -1,0 +1,298 @@
+import os, re, tempfile, json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from bson import ObjectId
+
+from app.db.mongo import get_db, get_fs
+from app.db.db_upload import preprocessor_upload_file, preprocessor_save_prompt
+from app.domains.messages.service import get_latest_user_message_for_stage
+
+from app.domains.evidences.preprocessor.file_preprocessing import convert_files_to_json, DATA_DIR
+from app.domains.evidences.preprocessor.text_preprocessing import inline_to_grouped_json
+
+INPUT_EVIDENCE_COLL = os.getenv("INPUT_EVIDENCE_COLL")
+
+SUPPORTED_INPUT_EXTS = {".json", ".jsonl", ".xml", ".csv"}
+UNSUPPORTED_KNOWN_EXTS = {".001", ".evtx", ".pcap", ".pcapng", ".vmdk", ".img", ".zip", ".gz", ".xz"}
+ALLOWED_EXTS_FOR_DETECTION = SUPPORTED_INPUT_EXTS | UNSUPPORTED_KNOWN_EXTS
+
+def _is_safe_relative_under_data(token: str) -> bool:
+    try:
+        p = Path(token.strip().strip('\'"'))
+    except Exception:
+        return False
+    if p.is_absolute():
+        return False
+
+    try:
+        normalized = p.resolve().parts
+    except Exception:
+        normalized = p.parts
+    if any(part == ".." for part in p.parts):
+        return False
+
+    s = str(p)
+    if not s or len(s) > 255 or any(ch in s for ch in ["\n", "\r", "\t"]):
+        return False
+    return True
+
+def _ext_of(token: str) -> str:
+    try:
+        return Path(token.strip().strip('\'"')).suffix.lower()
+    except Exception:
+        return ""
+
+def _looks_like_filename(token: str) -> bool:
+    t = token.strip().strip('\'"')
+    if not t or " " in t:
+        return False
+
+    if ":" in t and not ("/" in t or "\\" in t):
+        return False
+    if t.startswith(("http://", "https://")):
+        return False
+    ext = _ext_of(t)
+    if ext not in ALLOWED_EXTS_FOR_DETECTION:
+        return False
+    if not _is_safe_relative_under_data(t):
+        return False
+    return True
+
+def _split_message_to_files_and_inline(msg: str) -> Tuple[List[str], List[str], List[str]]:
+    processable_files: List[str] = []
+    inline_blocks: List[str] = []
+    unprocessed: List[str] = []
+
+    tokens = re.split(r"[\s,;]+", msg or "")
+    candidates: List[str] = []
+    for t in tokens:
+        if not t:
+            continue
+        if _looks_like_filename(t):
+            candidates.append(t.strip().strip('\'"'))
+
+    seen = set()
+    uniq_candidates: List[str] = []
+    for c in candidates:
+        if c not in seen:
+            seen.add(c)
+            uniq_candidates.append(c)
+
+    for rel in uniq_candidates:
+        path = DATA_DIR / rel
+        ext = _ext_of(rel)
+        if path.exists():
+            if ext in SUPPORTED_INPUT_EXTS:
+                processable_files.append(rel)
+            else:
+                unprocessed.append(rel)
+
+    blocks, cur = [], []
+    for line in (msg or "").splitlines():
+        if line.strip() == "":
+            if cur:
+                blocks.append("\n".join(cur).strip()); cur = []
+        else:
+            cur.append(line)
+    if cur:
+        blocks.append("\n".join(cur).strip())
+
+    def looks_structured(s: str) -> bool:
+        s2 = s.strip()
+        if not s2:
+            return False
+        if s2.startswith("{") or s2.startswith("["):
+            try:
+                json.loads(s2); return True
+            except Exception:
+                pass
+        if s2.startswith("<") and s2.endswith(">"):
+            return True
+        if ("," in s2 or "\t" in s2) and not any(ch in s2 for ch in "{}<>"):
+            return True
+        return False
+
+    for b in blocks:
+        lines = [ln.strip() for ln in b.splitlines() if ln.strip()]
+        if lines and all(_looks_like_filename(ln) for ln in lines):
+            continue
+        if looks_structured(b):
+            inline_blocks.append(b)
+
+    return sorted(set(processable_files)), inline_blocks, unprocessed
+
+def _clean_instruction_text(msg: str, file_names: List[str], inline_blocks: List[str], unprocessed: List[str]) -> str:
+    if not msg:
+        return ""
+    known_files = {Path(f).name.lower() for f in (set(file_names) | set(unprocessed))}
+    cleaned: List[str] = []
+    for ln in msg.splitlines():
+        s = ln.strip()
+        if not s:
+            continue
+        if Path(s).name.lower() in known_files:
+            continue
+        if s.startswith("{") or s.startswith("[") or s.startswith("<") or ("," in s or "\t" in s):
+            try:
+                json.loads(s)
+                continue
+            except Exception:
+                if s.startswith("<") or ("," in s or "\t" in s):
+                    continue
+        cleaned.append(s)
+    return "\n".join(cleaned).strip()
+
+def create_evidences_from_latest_message(
+    *,
+    conversation_id: str,
+    mode: str = "auto",
+    inline_threshold: int = 10 * 1024 * 1024,
+) -> Dict[str, Any]:
+    db = get_db()
+    msg = get_latest_user_message_for_stage(conversation_id)
+    if not msg:
+        raise ValueError("해당 conversation의 user 메시지가 없습니다.")
+
+    file_names, inline_blocks, unprocessed = _split_message_to_files_and_inline(msg["content"])
+
+    with tempfile.TemporaryDirectory() as td:
+        out_dir = Path(td)
+        out_paths: List[str] = []
+
+        if file_names:
+            out_paths += convert_files_to_json(file_names, out_dir=str(out_dir))
+
+        if inline_blocks:
+            grouped = inline_to_grouped_json(inline_blocks)
+            inline_path = out_dir / "inline_batch.json"
+            inline_path.write_text(json.dumps(grouped, ensure_ascii=False, indent=2), encoding="utf-8")
+            out_paths.append(str(inline_path))
+
+        instruction = _clean_instruction_text(msg["content"], file_names, inline_blocks, unprocessed)
+        
+        prompt_id = preprocessor_save_prompt(
+            user_prompt=instruction,
+            unprocessed_filenames=sorted(set(unprocessed)),
+            inline_text_blobs=[],
+            attachments=[],
+            context_tags=[],
+        )
+
+        results: List[Dict[str, Any]] = []
+        for p in out_paths:
+            try:
+                r = preprocessor_upload_file(
+                    file_path=p,
+                    detected_type="json",
+                    mode=mode,
+                    inline_threshold_bytes=inline_threshold,
+                    extra_meta={
+                        "conversation_id": ObjectId(conversation_id) if ObjectId.is_valid(conversation_id) else conversation_id,
+                        "prompt_ref": ObjectId(prompt_id),
+                    },
+                )
+                meta = db[INPUT_EVIDENCE_COLL].find_one({"_id": ObjectId(r["meta_id"])}, {"filename": 1, "size": 1})
+                results.append({
+                    "evidence_id": r["meta_id"],
+                    "type": "json",
+                    "strategy": "gridfs" if "gridfs_id" in r else "inline",
+                    "data_gridfs_id": r.get("gridfs_id"),
+                    "filename": (meta or {}).get("filename") or Path(p).name,
+                    "size": int((meta or {}).get("size") or 0),
+                })
+            except Exception as e:
+                results.append({
+                    "evidence_id": "",
+                    "type": "json",
+                    "strategy": "inline",
+                    "data_gridfs_id": None,
+                    "filename": Path(p).name,
+                    "size": 0,
+                    "error": str(e),
+                })
+
+    return {"prompt_id": str(prompt_id), "items": results}
+
+def list_input_evidences(conversation_id: Optional[str], stage_id: Optional[int], limit: int = 100) -> List[Dict[str, Any]]:
+    db = get_db()
+    q: Dict[str, Any] = {}
+    if conversation_id:
+        q["conversation_id"] = ObjectId(conversation_id) if ObjectId.is_valid(conversation_id) else conversation_id
+    if stage_id is not None:
+        q["stage_id"] = int(stage_id)
+    cur = db[INPUT_EVIDENCE_COLL].find(q, {
+        "filename": 1, "size": 1, "created_at": 1, "conversation_id": 1, "stage_id": 1
+    }).sort("created_at", -1).limit(limit)
+
+    out: List[Dict[str, Any]] = []
+    for d in cur:
+        out.append({
+            "_id": str(d["_id"]),
+            "conversation_id": str(d.get("conversation_id")) if isinstance(d.get("conversation_id"), ObjectId) else d.get("conversation_id"),
+            "stage_id": d.get("stage_id"),
+            "filename": d.get("filename"),
+            "size": d.get("size"),
+            "created_at": d.get("created_at"),
+        })
+    return out
+
+def get_input_evidence_detail(evidence_id: str) -> Optional[Dict[str, Any]]:
+    db = get_db(); fs = get_fs(db)
+    if not ObjectId.is_valid(evidence_id):
+        return None
+    d = db[INPUT_EVIDENCE_COLL].find_one({"_id": ObjectId(evidence_id)})
+    if not d:
+        return None
+
+    detail: Dict[str, Any] = {
+        "_id": str(d["_id"]),
+        "conversation_id": str(d.get("conversation_id")) if isinstance(d.get("conversation_id"), ObjectId) else d.get("conversation_id"),
+        "stage_id": d.get("stage_id"),
+        "filename": d.get("filename"),
+        "size": d.get("size"),
+        "data_gridfs_id": None,
+        "ingested_at": d.get("ingested_at"),
+        "data": None,
+    }
+
+    if d.get("data") is not None:
+        try:
+            if isinstance(d["data"], (dict, list)):
+                detail["data"] = d["data"]
+            else:
+                detail["data"] = json.loads(d["data"])
+        except Exception:
+            detail["data"] = None
+    elif d.get("raw") is not None:
+        try:
+            detail["data"] = json.loads(bytes(d["raw"]).decode("utf-8", errors="ignore"))
+        except Exception:
+            detail["data"] = None
+    elif d.get("gridfs_id"):
+        detail["data_gridfs_id"] = str(d["gridfs_id"])
+    return detail
+
+
+def preview_input_evidence(evidence_id: str, limit: int = 64 * 1024):
+    db = get_db()
+    fs = get_fs(db)
+
+    if not ObjectId.is_valid(evidence_id):
+        return None
+
+    d = db[INPUT_EVIDENCE_COLL].find_one({"_id": ObjectId(evidence_id)})
+    if not d:
+        return None
+
+    if d.get("data") is not None:
+        return {"type": "inline", "data": d["data"]}
+
+    gid = d.get("gridfs_id")
+    if not gid:
+        return {"type": "none"}
+
+    g = fs.get(gid)
+    head = g.read(limit)
+    ctype = d.get("content_type", "application/octet-stream")
+
+    return {"type": "gridfs", "content_type": ctype, "preview": head}

--- a/backend/app/domains/messages/schema.py
+++ b/backend/app/domains/messages/schema.py
@@ -1,6 +1,6 @@
 from typing import Literal, List
 from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 class MessageCreate(BaseModel):
     role: Literal["USER", "B-GENT"]

--- a/backend/app/domains/messages/service.py
+++ b/backend/app/domains/messages/service.py
@@ -75,3 +75,29 @@ def get_message_detail(conversation_id: str, message_id: str) -> Optional[Dict[s
         "role": doc["role"],
         "content": doc["content"],
     }
+
+
+def get_latest_user_message_for_stage(conversation_id: str) -> Optional[Dict[str, Any]]:
+    if not conversation_id or not ObjectId.is_valid(conversation_id):
+        raise ValueError("invalid conversation_id")
+
+    db = get_db()
+    doc = db[MSG_COLL].find_one(
+        {
+            "conversation_id": ObjectId(conversation_id),
+            "stage_id": 1,
+            "role": "USER",
+        },
+    )
+
+    if not doc:
+        return None
+
+    return {
+        "_id": str(doc["_id"]),
+        "conversation_id": conversation_id,
+        "role": doc["role"],
+        "stage_id": doc["stage_id"],
+        "content": doc["content"],
+        "created_at": doc.get("created_at"),
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,9 +3,11 @@ from fastapi import FastAPI
 from app.domains.conversations.router import router as conversations_router
 from app.domains.messages.router import router as messages_router
 from app.domains.triggers.router import router as triggers_router
+from app.domains.evidences.router import router as evidences_router
 
 app = FastAPI(title="B-gent API", version="1.0.0", description="B-gent Backend API",)
 
 app.include_router(conversations_router, prefix="/conversations", tags=["Conversations"])
 app.include_router(messages_router, prefix="/conversations", tags=["Messages"])
 app.include_router(triggers_router, prefix="/triggers", tags=["Triggers"])
+app.include_router(evidences_router, prefix="/evidences", tags=["Evidences"])


### PR DESCRIPTION
## 연관된 이슈
#27 

## 작업 내용 
1. 기존 전처리기 기능 API로 변경
2. conversation_id를 넣으면 해당 대화의 stage 1 user message를 받아 파싱 후, Agent와 sLLM에 전달하기 위한 지시문만 저장하도록 구현
3. 10MB가 넘는 파일일 경우 GridFS로 저장하도록 구현
4. GridFS로 저장된 파일은 sample만 확인 가능

## 스크린샷
<img width="1436" height="272" alt="스크린샷 2025-10-29 오후 10 03 23" src="https://github.com/user-attachments/assets/b6cfd38c-74c9-4d23-9ffc-4e31483982e5" />
<img width="1104" height="561" alt="스크린샷 2025-10-29 오후 10 04 07" src="https://github.com/user-attachments/assets/6c072605-3932-4844-930a-4f67704aed9c" />
<img width="1107" height="252" alt="스크린샷 2025-10-29 오후 10 04 25" src="https://github.com/user-attachments/assets/b878d17f-c5ef-4ea3-8a92-9b7eeee8fcf8" />

## 리뷰 요구사항
