### PR TITLE
[FIX] 스테이지 별 증거 저장 로직 변경

### DIFF
--- a/backend/app/domains/conversations/router.py
+++ b/backend/app/domains/conversations/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, Query
 from app.domains.conversations.schema import ConversationCreateInput, ConversationCreatedOut, ConversationDetailOut, ConversationListOut, ConversationReportsOut
-from app.domains.conversations.service import create_conversation_with_input, get_conversation_detail, list_conversations, get_conversation_reports
+from app.domains.conversations.service import create_conversation_with_input, get_conversation_detail, list_conversations, get_conversation_reports, update_last_stage
 
 from app.domains.triggers.service import get_triggers_by_conversation_id
 from app.domains.triggers.schema import TriggerListOut
@@ -49,3 +49,13 @@ def get_reports_for_conversation(conversation_id: str):
         raise HTTPException(status_code=404, detail="reports not found")
 
     return data
+
+@router.patch("/{conversation_id}/stage", summary="대화의 last_stage_id 업데이트")
+def update_conversation_stage(conversation_id: str, stage_id: int = Query(..., ge=1)):
+    try:
+        out = update_last_stage(conversation_id, stage_id)
+        if not out:
+            raise HTTPException(status_code=404, detail="conversation not found")
+        return out
+    except ValueError as e:
+        raise HTTPException(400, str(e))

--- a/backend/app/domains/conversations/service.py
+++ b/backend/app/domains/conversations/service.py
@@ -117,3 +117,32 @@ def get_conversation_reports(conversation_id: str) -> Optional[Dict[str, Any]]:
         "conversation_id": conversation_id,
         "items": items,
     }
+
+def update_last_stage(conversation_id: str, stage_id: int) -> Optional[Dict[str, Any]]:
+    if not ObjectId.is_valid(conversation_id):
+        raise ValueError("invalid conversation_id")
+
+    db = get_db()
+    oid = ObjectId(conversation_id)
+
+    res = db[CONV_COLL].find_one_and_update(
+        {"_id": oid},
+        {
+            "$set": {
+                "last_stage_id": stage_id,
+                "updated_at": _now(),
+            }
+        },
+        return_document=True,
+    )
+
+    if not res:
+        return None
+
+    return {
+        "_id": str(res["_id"]),
+        "title": res.get("title", ""),
+        "last_stage_id": res.get("last_stage_id"),
+        "created_at": res.get("created_at"),
+        "updated_at": res.get("updated_at"),
+    }

--- a/backend/app/domains/evidences/router.py
+++ b/backend/app/domains/evidences/router.py
@@ -8,7 +8,7 @@ router = APIRouter()
 @router.post("/input", response_model=EvidenceCreatedOut, summary="사용자 프롬프트 내용에서 전처리기 증거 추출 및 변환 후 저장")
 def create_from_conversation(body: EvidenceFromConversationIn):
     try:
-        res = create_evidences_from_latest_message(conversation_id=body.conversation_id, inline_threshold=body.inline_threshold)
+        res = create_evidences_from_latest_message(conversation_id=body.conversation_id, stage_id=body.stage_id or 1, inline_threshold=body.inline_threshold)
         return EvidenceCreatedOut.model_validate(res)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/domains/evidences/schema.py
+++ b/backend/app/domains/evidences/schema.py
@@ -6,6 +6,7 @@ class EvidenceFromConversationIn(BaseModel):
     conversation_id: str
     mode: Optional[str] = Field("auto")
     inline_threshold: int = 10 * 1024 * 1024
+    stage_id: int
 
 class EvidenceCreatedItem(BaseModel):
     evidence_id: str

--- a/backend/app/domains/evidences/service.py
+++ b/backend/app/domains/evidences/service.py
@@ -145,11 +145,12 @@ def _clean_instruction_text(msg: str, file_names: List[str], inline_blocks: List
 def create_evidences_from_latest_message(
     *,
     conversation_id: str,
+    stage_id: int,
     mode: str = "auto",
     inline_threshold: int = 10 * 1024 * 1024,
 ) -> Dict[str, Any]:
     db = get_db()
-    msg = get_latest_user_message_for_stage(conversation_id)
+    msg = get_latest_user_message_for_stage(conversation_id, stage_id)
     if not msg:
         raise ValueError("해당 conversation의 user 메시지가 없습니다.")
 
@@ -188,6 +189,7 @@ def create_evidences_from_latest_message(
                     inline_threshold_bytes=inline_threshold,
                     extra_meta={
                         "conversation_id": ObjectId(conversation_id) if ObjectId.is_valid(conversation_id) else conversation_id,
+                        "stage_id": stage_id,
                         "prompt_ref": ObjectId(prompt_id),
                     },
                 )

--- a/backend/app/domains/messages/service.py
+++ b/backend/app/domains/messages/service.py
@@ -77,7 +77,7 @@ def get_message_detail(conversation_id: str, message_id: str) -> Optional[Dict[s
     }
 
 
-def get_latest_user_message_for_stage(conversation_id: str) -> Optional[Dict[str, Any]]:
+def get_latest_user_message_for_stage(conversation_id: str, stage_id: int) -> Optional[Dict[str, Any]]:
     if not conversation_id or not ObjectId.is_valid(conversation_id):
         raise ValueError("invalid conversation_id")
 
@@ -85,9 +85,10 @@ def get_latest_user_message_for_stage(conversation_id: str) -> Optional[Dict[str
     doc = db[MSG_COLL].find_one(
         {
             "conversation_id": ObjectId(conversation_id),
-            "stage_id": 1,
+            "stage_id": stage_id,
             "role": "USER",
         },
+        sort=[("created_at", -1), ("_id", -1)]
     )
 
     if not doc:

--- a/backend/app/domains/pipeline/service.py
+++ b/backend/app/domains/pipeline/service.py
@@ -96,6 +96,7 @@ async def run_pipeline_service(*, input_text: str, stage_id: int = 0, inline_thr
             "/evidences/input",
             json={
                 "conversation_id": conversation_id,
+                "stage_id": stage_id,
                 "mode": mode,
                 "inline_threshold": inline_threshold,
             },
@@ -161,6 +162,13 @@ async def run_pipeline_service(*, input_text: str, stage_id: int = 0, inline_thr
                     "content": bgent_msg,
                 },
             )
+
+        await _http_json(
+            client,
+            "PATCH",
+            f"/conversations/{conversation_id}/stage",
+            params={"stage_id": stage_id},
+        )
 
     return {
         "conversation_id": conversation_id,

--- a/frontend/apps/renderer/src/components/Diagram.tsx
+++ b/frontend/apps/renderer/src/components/Diagram.tsx
@@ -282,11 +282,11 @@ function DiagramInner({ sidebarOpen }: { sidebarOpen: boolean }) {
         data: e.data ?? {},
       }))
 
-      putUILayout(conversationId, STAGE_ID, { nodes: dtoNodes, edges: dtoEdges }).catch(err => {
+      putUILayout(conversationId, currentStageId, { nodes: dtoNodes, edges: dtoEdges }).catch(err => {
         console.warn('[Diagram] putUILayout failed:', err)
       })
     }, 800) as unknown as number
-  }, [nodes, edges, conversationId, STAGE_ID])
+  }, [nodes, edges, conversationId, currentStageId])
 
   useEffect(() => {
     scheduleFit(50)

--- a/frontend/apps/renderer/src/store/ui.ts
+++ b/frontend/apps/renderer/src/store/ui.ts
@@ -150,6 +150,8 @@ export const useUIStore = create<UIState>((set, get) => ({
       panelMessages: [],
       totalReportRaw: '',
       currentTriggerId: null,
+      currentStageId: 1,
+      loadedConversationTitle: null,
     }),
 
   sidebarOpen: false,

--- a/frontend/apps/renderer/src/utils/api.ts
+++ b/frontend/apps/renderer/src/utils/api.ts
@@ -14,6 +14,7 @@ export type CreateTriggerRes = { trigger_id: string; status: string; created_at:
 
 export type CreateInputEvidencesReq = {
   conversation_id: string
+  stage_id: number
   mode: 'auto' | 'manual'
   inline_threshold: number
 }
@@ -234,7 +235,7 @@ export type TriggerDoc = {
 
   prompt_id?: OID
 
-  status?: 'pending' | 'processing' | 'done' | 'error'
+  status?: 'initial' | 'collecting' | 'ready' | 'processing' | 'done'
 
   report_id?: OID
 
@@ -247,8 +248,8 @@ export async function getTrigger(triggerId: string): Promise<TriggerDoc> {
 }
 
 export async function getLatestReportId(): Promise<string | null> {
-  const res = await http<{ items?: Array<{ _id: string }> }>(`/reports?limit=1`)
-  return res.items?.[0]?._id ?? null
+  const res = await http<{ _id: string }>(`/reports/latest`)
+  return res._id ?? null
 }
 
 export async function listConversations(): Promise<ConversationSummary[]> {
@@ -260,6 +261,17 @@ export async function getConversation(conversationId: string): Promise<Conversat
   return http<ConversationSummary>(`/conversations/${encodeURIComponent(conversationId)}`, {
     method: 'GET',
   })
+}
+
+export async function updateConversationStage(
+  conversationId: string,
+  stageId: number
+): Promise<ConversationSummary> {
+  const qs = new URLSearchParams({ stage_id: String(stageId) })
+  return http<ConversationSummary>(
+    `/conversations/${encodeURIComponent(conversationId)}/stage?${qs.toString()}`,
+    { method: 'PATCH' }
+  )
 }
 
 export async function getMessages(


### PR DESCRIPTION
## 연관된 이슈
#81

## 작업 내용 
- stage_id를 적용한 메시지 로드
- conversation의 last_stage_id 변경 로직 추가

## 스크린샷

